### PR TITLE
Fix #1: random test failures because of dict

### DIFF
--- a/tests/test_flume_render.py
+++ b/tests/test_flume_render.py
@@ -59,9 +59,6 @@ class TestFlumeRender(unittest.TestCase):
         self.assertEqual(render(input, self.namespace), expected)
 
     def test_multiline_substitution(self):
-        input = """{{ str({
-            "foo": "bar",
-            "bar": "baz",
-        }) }}"""
-        expected = "{'foo': 'bar', 'bar': 'baz'}"
+        input = """{{ str(["foo", "bar", "baz"]) }}"""
+        expected = "['foo', 'bar', 'baz']"
         self.assertEqual(render(input, self.namespace), expected)


### PR DESCRIPTION
This fixes the issue with the failing test by switching the rendering to acting on a list as opposed to on a dict which is unordered leading to intermittent test failures.