### PR TITLE
Fix issue where --end-lines was only executed when all tests pass

### DIFF
--- a/flume/flume.py
+++ b/flume/flume.py
@@ -34,7 +34,7 @@ def _exec_list(exprs, namespace):
         if os.path.isfile(_expr):
             namespace.update(runpy.run_path(_expr, init_globals=namespace))
         else:
-            exec(render(_expr, namespace), namespace)
+            exec(_expr, namespace)
 
 def make_namespace(namespaces, add_env):
     namespace = {}
@@ -151,8 +151,6 @@ def stream(
             format=logging_format,
         )
 
-    if templates is None:
-        templates = ["{{line}}"]
     if add_paths is None:
         add_paths = []
     for path in add_paths:
@@ -220,16 +218,15 @@ def stream(
                                 continue
                             if results:
                                 logging.getLogger(
-                                    "{}.{}.{}.{}".format(
+                                    "{}.{}.{}".format(
                                         __name__,
                                         filename,
                                         templates.index(template),
-                                        fnr,
                                     )
                                 ).info(
                                     results
                                 )
-                        _exec_list(end_lines, namespace)
+                    _exec_list(end_lines, namespace)
             _exec_list(end_files, namespace)
         except:
             if not suppress_tracebacks:

--- a/test.txt
+++ b/test.txt
@@ -1,0 +1,3 @@
+foo 
+bar 
+foobar 

--- a/tests/test_flume.py
+++ b/tests/test_flume.py
@@ -2,29 +2,108 @@
 # -*- coding: utf-8 -*-
 
 """Tests for `flume` package."""
-
-
 import unittest
+import logging
+from flume.flume import cli
 from click.testing import CliRunner
 
-from flume.flume import cli
 
-
-class TestFlume(unittest.TestCase):
-    """Tests for `flume` package."""
+class TestFlumeStream(unittest.TestCase):
+    """Tests for `flume stream` subcommand."""
 
     def setUp(self):
         """Set up test fixtures, if any."""
+        # Need this to overcome an issue with testing
+        # basically clearing configuration from the last
+        # call to invoke because, i think, that between
+        # calls sys.stdout is replaced but logging configuration
+        # persists through runs leaving a stale reference to
+        # the old sys.stdout
+        logging.getLogger("").handlers = []
+
 
     def tearDown(self):
         """Tear down test fixtures, if any."""
 
-    def test_000_something(self):
-        """Test something."""
+    def test_simple_substitution(self):
+        """Test that simple substitution works."""
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            args=(
+                "stream",
+                "--templates",
+                "{{line.decode()}}"
+            ),
+            input="foo"
+        )
+        expected = "foo\n"
+        self.assertEqual(expected, result.output)
 
-    def test_command_line_interface(self):
+    def test_begin_lines_only_executed_when_tests_pass(self):
+        """Test `--begin-lines` is only executed when all tests pass."""
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            args=(
+                "stream",
+                "--tests", "'bar' in line.decode()",
+                "--begin-lines", "print(line.decode(), end='')"
+            ),
+            input="foo\nbar\n"
+        )
+        expected = "bar\n"
+        self.assertEqual(expected, result.output)
+
+    def test_end_lines_only_executed_when_tests_pass(self):
+        """Test `--end-lines` is only executed regardless of the results of test."""
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            args=(
+                "stream",
+                "--tests", "'bar' in line.decode().strip()",
+                "--end-lines", "print(line.decode().strip())",
+            ),
+            input="foo\nbar\n"
+        )
+        expected = "foo\nbar\n"
+        self.assertEqual(expected, result.output)
+
+    def test_only_renders_if_test_pass(self):
+        """Test that templates only render if test passes."""
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            args=(
+                "stream",
+                "--tests", "'bar' in line.decode()",
+                "--templates", "{{line.decode()}}"
+            ),
+            input="foo\nbar"
+        )
+        expected = "bar\n"
+        self.assertEqual(expected, result.output)
+
+    def test_only_renders_if_all_tests_pass(self):
+        """Test that templates only render if all tests passes."""
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            args=(
+                "stream",
+                "--tests", "'bar' in line.decode()",
+                "--tests", "'foo' in line.decode()",
+                "--templates", "{{line.decode()}}",
+            ),
+            input="foo\nbar\nfoobar",
+        )
+        expected = "foobar\n"
+        self.assertEqual(expected, result.output)
+
+    def test_help_menu(self):
         """Test the CLI."""
         runner = CliRunner()
-        help_result = runner.invoke(cli, ['--help'])
+        help_result = runner.invoke(cli, ['stream', '--help'])
         self.assertEqual(help_result.exit_code, 0)
-        self.assertIn('--help  Show this message and exit.', help_result.output)
+        self.assertIn('Show this message and exit.', help_result.output)


### PR DESCRIPTION
Didn't mean to use this branch again, but I will merge and use better practices in  the future. 

I fixed the issue where --end-lines was only executed when the tests pass, but it should be executed regardless.

Also added a bunch of tests.